### PR TITLE
updated Vagrantfile to install Cloud Foundry CLI

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,10 @@ Vagrant.configure(2) do |config|
       echo "\n************************************"
       echo " For the Kubernetes Dashboard use:"
       echo " kubectl proxy --address='0.0.0.0'"
-      echo "************************************\n"   
+      echo "************************************\n"
+      echo "Installing Cloud Foundry CLI"
+      ibmcloud cf install
+      echo "Cloud Foundry CLI Installed"   
     SHELL
   
   end

--- a/login-ibm-cloud.sh
+++ b/login-ibm-cloud.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+sh -c 'ibmcloud login -a https://cloud.ibm.com --apikey @~/.bluemix/apiKey.json -r us-south -g Default' echo "\n"
+sh -c "ibmcloud target --cf"


### PR DESCRIPTION
I also added a login-ibm-cloud.sh file which just runs the login commands to make life a little easier. This file can be run from the /vagrant folder using the command: `bash login-ibm-cloud.sh`